### PR TITLE
Add previewType props to Scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 *.tsbuildinfo
+
+# Intelij IDE
+.idea

--- a/docs/en-us/components.md
+++ b/docs/en-us/components.md
@@ -70,6 +70,7 @@ Represent krpano scenes
 |:--|:--:|:--:|:--|
 | name | string | ✅ | Scene name |
 | previewUrl | string | | Preview image url, usually a low-quality image |
+| previewType | string | | Preview type to use type="grid" |
 | content | string | | Directly specify the xml content of the scene tag, other settings will be ignored after use |
 | imageTagAttributes | Record | | Set image tag attributes, see the [official documentation](https://krpano.com/docu/xml/#image) for details |
 | images | [SceneImage] or SceneImageWithMultires[] | | Define picture to display in the scene. When length > 1, it will trigger [multires](https://krpano.com/examples/?multires) |

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -21,6 +21,7 @@ export interface SceneImageWithMultires {
 export interface SceneProps {
     name: string;
     previewUrl?: string;
+    previewType?: string;
     /** 直接指定scene的xml内容。指定后会忽略其他设置 */
     content?: string;
     /** image标签的附加属性，仅少部分情况用到 */
@@ -32,6 +33,7 @@ export interface SceneProps {
 export const Scene: React.FC<SceneProps> = ({
     name,
     previewUrl,
+    previewType,
     imageTagAttributes = {},
     images = [],
     content,
@@ -86,12 +88,12 @@ export const Scene: React.FC<SceneProps> = ({
             });
         }
 
+        const previewTag = `<preview ${previewUrl ? `url="${previewUrl}` : ''} 
+                            ${previewType ? `type="${previewType}` : ''}" />`;
         renderer?.setTag('scene', name, {
             content:
                 content ||
-                `${previewUrl ? `<preview url="${previewUrl}" />` : ''}${
-                    images.length > 0 ? buildXML(contentImageMeta) : ''
-                }`,
+                `${previewUrl || previewType ? previewTag : ''} ${images.length > 0 ? buildXML(contentImageMeta) : ''}`,
         });
 
         return () => {


### PR DESCRIPTION
Add previewType props to Scene components to allow usage of type="grid" on preview tag
EN doc updated to add the prop description